### PR TITLE
Observe only if instance of ValidableContract

### DIFF
--- a/src/Validable.php
+++ b/src/Validable.php
@@ -4,6 +4,7 @@ namespace Sofa\Eloquence;
 
 use Sofa\Eloquence\Validable\Observer;
 use Illuminate\Contracts\Validation\Factory;
+use Sofa\Eloquence\Contracts\Validable as ValidableContract;
 
 /**
  * @method integer getKey()
@@ -48,7 +49,9 @@ trait Validable
      */
     public static function bootValidable()
     {
-        static::observe(new Observer);
+        if (is_subclass_of(static::class, ValidableContract::class)) {
+            static::observe(new Observer);
+        }
 
         if (!static::$validatorFactory) {
             if (function_exists('app') && app()->bound('validator')) {


### PR DESCRIPTION
Same reasoning as https://github.com/jarektkaczyk/eloquence-base/pull/34

I would like to use the eloquence-validable, but without automatic validation upon saving/updating. This PR ensures that the observer is not registered, if the model does not implement ValidableContract.