### PR TITLE
Fix isValid method

### DIFF
--- a/src/Validable.php
+++ b/src/Validable.php
@@ -64,7 +64,9 @@ trait Validable
      */
     public function isValid()
     {
-        $this->getValidator()->setData($this->getAttributes());
+        $this->getValidator()
+            ->setRules($this->exists ? $this->getUpdateRules() : $this->getCreateRules())
+            ->setData($this->getAttributes());
 
         return $this->getValidator()->passes();
     }

--- a/src/Validable/Observer.php
+++ b/src/Validable/Observer.php
@@ -41,29 +41,7 @@ class Observer
      */
     public function updating(Validable $model)
     {
-        if ($model->validationEnabled()) {
-            return $this->validateUpdate($model);
-        }
-    }
-
-    /**
-     * Halt updating if model doesn't pass validation.
-     *
-     * @param  \Sofa\Eloquence\Contracts\Validable $model
-     * @return void|false
-     */
-    protected function validateUpdate(Validable $model)
-    {
-        // When we are trying to update this model we need to set the update rules
-        // on the validator first, next we can determine if the model is valid,
-        // finally we restore original rules and notify in case of failure.
-        $model->getValidator()->setRules($model->getUpdateRules());
-
-        $valid = $model->isValid();
-
-        $model->getValidator()->setRules($model->getCreateRules());
-
-        if (!$valid) {
+        if ($model->validationEnabled() && !$model->isValid()) {
             return false;
         }
     }

--- a/tests/ValidableObserverTest.php
+++ b/tests/ValidableObserverTest.php
@@ -47,15 +47,8 @@ class ValidableObserverTest extends \PHPUnit_Framework_TestCase {
     {
         $observer = new Observer;
 
-        $validator = m::mock('\Illuminate\Contracts\Validation\Validator');
-        $validator->shouldReceive('setRules')->once()->with(['update_rules'])->andReturn($validator);
-        $validator->shouldReceive('setRules')->once()->with(['create_rules'])->andReturn($validator);
-
         $validable = m::mock('\Sofa\Eloquence\Contracts\Validable');
         $validable->shouldReceive('validationEnabled')->once()->andReturn(true);
-        $validable->shouldReceive('getValidator')->twice()->andReturn($validator);
-        $validable->shouldReceive('getUpdateRules')->once()->andReturn(['update_rules']);
-        $validable->shouldReceive('getCreateRules')->once()->andReturn(['create_rules']);
         $validable->shouldReceive('isValid')->once()->andReturn(false);
 
         $this->assertFalse($observer->updating($validable));
@@ -81,15 +74,8 @@ class ValidableObserverTest extends \PHPUnit_Framework_TestCase {
     {
         $observer = new Observer;
 
-        $validator = m::mock('\Illuminate\Contracts\Validation\Validator');
-        $validator->shouldReceive('setRules')->once()->with(['update_rules'])->andReturn($validator);
-        $validator->shouldReceive('setRules')->once()->with(['create_rules'])->andReturn($validator);
-
         $validable = m::mock('\Sofa\Eloquence\Contracts\Validable');
         $validable->shouldReceive('validationEnabled')->once()->andReturn(true);
-        $validable->shouldReceive('getValidator')->twice()->andReturn($validator);
-        $validable->shouldReceive('getUpdateRules')->once()->andReturn(['update_rules']);
-        $validable->shouldReceive('getCreateRules')->once()->andReturn(['create_rules']);
         $validable->shouldReceive('isValid')->once()->andReturn(true);
 
         $this->assertNull($observer->updating($validable));

--- a/tests/ValidableTest.php
+++ b/tests/ValidableTest.php
@@ -130,6 +130,9 @@ class ValidableTest extends \PHPUnit_Framework_TestCase {
     public function it_checks_all_the_attributes()
     {
         $model = $this->getModel();
+        $model->getValidator()->shouldReceive('setRules')
+            ->with($model->exists ? $model->getUpdateRules() : $model->getCreateRules())
+            ->andReturnSelf();
         $model->getValidator()->shouldReceive('setData')->with($model->getAttributes());
         $this->assertTrue($model->isValid());
     }


### PR DESCRIPTION
isValid method in its current form doesn't work when the model exists. This is due to the model's validator always being set to create rules.

My PR makes a change, so when isValid is called, "exists" property of the model is checked and then the appropriate rule set is set to the validator. This way the isValid method will work properly in case the model exists in DB or if it does not.

I also applied this fix to the Observer and adjusted the tests as necessary.