### PR TITLE
Support the creation of rules through generateXxxxRules() methods

### DIFF
--- a/src/Validable.php
+++ b/src/Validable.php
@@ -303,6 +303,12 @@ trait Validable
             }
         }
 
+        foreach (get_class_methods(get_called_class()) as $method) {
+            if (preg_match('/^generate.*rules$/i', $method)) {
+                $groups[] = "method:$method";
+            }
+        }
+
         return $groups;
     }
 
@@ -314,6 +320,12 @@ trait Validable
      */
     protected static function getRulesGroup($group)
     {
+        if(substr($group, 0, 7) === 'method:') {
+            $method = substr($group, 7);
+            
+            return static::$method();
+        }
+
         return static::$$group;
     }
 

--- a/tests/ValidableTest.php
+++ b/tests/ValidableTest.php
@@ -110,6 +110,7 @@ class ValidableTest extends TestCase
             'name' => ['required', 'max:10', 'unique:users,username,null,id,account_id,5', 'max:255'],
             'age' => ['min:5'],
             'last_name' => ['max:255'],
+            'city' => ['max:255'],
         ];
 
         $this->assertEquals($rulesMerged, $this->getModel()->getCreateRules());
@@ -127,7 +128,7 @@ class ValidableTest extends TestCase
     public function it_uses_rules_from_all_groups()
     {
         $model = $this->getModel();
-        $this->assertEquals(['email', 'name', 'age', 'last_name'], $model::getValidatedFields());
+        $this->assertEquals(['email', 'name', 'age', 'last_name', 'city'], $model::getValidatedFields());
     }
 
     protected function getModel()
@@ -156,4 +157,10 @@ class ValidableEloquentStub extends Model
         'name' => ['max:255'],
         'last_name' => ['max:255'],
     ];
+
+    protected static function generateCustomRules() {
+        return [
+            'city' => ['max:255'],
+        ];
+    }
 }


### PR DESCRIPTION
I had an issue while using the $xxxRules properties since they cannot contains methods in their declaration. And considering that some validators can be created through the Illuminate\Validation\Rule class to be given some more parameters, I had to support some sort of a method to generate rules.

This pull request adds the support to methods with the naming generateXxxxRules(), without modifying the core.

Example :
```php
protected static function generateDynamicRules() {
    return [
        'crew_code' => Rule::unique('App\Models\User')->where('active', 1),
    ];
}
```

This PR was tested in context and added to the unit testing.